### PR TITLE
修复 win下 Visual C++ Runtime ERR没有被拦截

### DIFF
--- a/include/co/log.h
+++ b/include/co/log.h
@@ -107,7 +107,36 @@ using namespace ___;
 // TLOG are logs grouped by the topic.
 // TLOG("xxx") << "hello xxx" << 23;
 // It is better to use a literal string for the topic.
+
+#ifndef _WIN32
 #define TLOG(topic) log::xx::TLogSaver(__FILE__, sizeof(__FILE__) - 1, __LINE__, topic).stream()
+#define _CO_LOG_STREAM(lv)  log::xx::LevelLogSaver(__FILE__, sizeof(__FILE__) - 1, __LINE__, lv).stream()
+#define _CO_FLOG_STREAM     log::xx::FatalLogSaver(__FILE__, sizeof(__FILE__) - 1, __LINE__).stream()
+#else
+template <typename T, size_t S>
+inline constexpr size_t get_file_name_offset(const T(&str)[S], size_t i = S - 1){
+    return (str[i] == '/' || str[i] == '\\') ? i + 1 : (i > 0 ? get_file_name_offset(str, i - 1) : 0);
+}
+template <typename T>
+inline constexpr size_t get_file_name_offset(T(&str)[1]){
+    return 0;
+}
+namespace utility {
+
+    template <typename T, T v>
+    struct const_expr_value
+    {
+        static constexpr const T value = v;
+    };
+}
+#define UTILITY_CONST_EXPR_VALUE(exp) ::utility::const_expr_value<decltype(exp), exp>::value
+#define __FILENAME__ &__FILE__[UTILITY_CONST_EXPR_VALUE(get_file_name_offset(__FILE__))]
+
+#define TLOG(topic) log::xx::TLogSaver(__FILENAME__, sizeof(__FILENAME__) - 1, __LINE__, topic).stream()
+#define _CO_LOG_STREAM(lv)  log::xx::LevelLogSaver(__FILENAME__, sizeof(__FILE__)-UTILITY_CONST_EXPR_VALUE(get_file_name_offset(__FILE__)) - 1, __LINE__, lv).stream()
+#define _CO_FLOG_STREAM     log::xx::FatalLogSaver(__FILENAME__, sizeof(__FILE__)-UTILITY_CONST_EXPR_VALUE(get_file_name_offset(__FILE__)) - 1, __LINE__).stream()
+#endif 
+
 #define TLOG_IF(topic, cond) if (cond) TLOG(topic)
 
 // DLOG  ->  debug log
@@ -119,8 +148,7 @@ using namespace ___;
 //
 // LOG << "hello world " << 23;
 // WLOG_IF(1 + 1 == 2) << "xx";
-#define _CO_LOG_STREAM(lv)  log::xx::LevelLogSaver(__FILE__, sizeof(__FILE__) - 1, __LINE__, lv).stream()
-#define _CO_FLOG_STREAM     log::xx::FatalLogSaver(__FILE__, sizeof(__FILE__) - 1, __LINE__).stream()
+
 #define DLOG  if (FLG_min_log_level <= log::xx::debug)   _CO_LOG_STREAM(log::xx::debug)
 #define LOG   if (FLG_min_log_level <= log::xx::info)    _CO_LOG_STREAM(log::xx::info)
 #define WLOG  if (FLG_min_log_level <= log::xx::warning) _CO_LOG_STREAM(log::xx::warning)

--- a/test/stack.cc
+++ b/test/stack.cc
@@ -23,10 +23,12 @@ void b() {
 void c() {
     b();
 }
-
+void d() {
+   throw std::runtime_error("test");
+}
 int main(int argc, char** argv) {
     flag::init(argc, argv);
-
+    
     if (FLG_m) {
         c();
     } else if (FLG_t) {
@@ -34,8 +36,7 @@ int main(int argc, char** argv) {
     } else {
         go(c);
     }
-
+    go (d);
     while (1) sleep::sec(1024);
-
     return 0;
 }

--- a/xmake.lua
+++ b/xmake.lua
@@ -12,7 +12,7 @@ set_languages("c++11")
 set_warnings("all")     -- -Wall
 --set_symbols("debug")    -- dbg symbols
 
-
+add_rules("mode.debug", "mode.release")
 if is_plat("windows") then
     set_optimize("fastest")  -- faster: -O2  fastest: -Ox  none: -O0
     add_cxflags("/EHsc")


### PR DESCRIPTION
1、修复 win下 Visual C++ Runtime ERR没有被拦截
2、co::log win下使用__FILENAME__替换__FILE__