### PR TITLE
add return value for api run_all_tests()

### DIFF
--- a/include/co/unitest.h
+++ b/include/co/unitest.h
@@ -8,7 +8,7 @@
 
 namespace unitest {
 
-__coapi void run_all_tests();
+__coapi int run_all_tests();
 
 __coapi void push_failed_msg(
     const fastring& test_name, const fastring& case_name, 

--- a/src/unitest.cc
+++ b/src/unitest.cc
@@ -37,7 +37,7 @@ void push_failed_msg(const fastring& test_name, const fastring& case_name,
     x[test_name][case_name].push_back(co::make<FailedMsg>(file, line, msg));
 }
 
-void run_all_tests() {
+int run_all_tests() {
     Timer t;
     int n = 0;
     auto& tests = gTests();
@@ -112,6 +112,8 @@ void run_all_tests() {
         cout << color::deflt;
         cout.flush();
     }
+
+    return failed.size();
 }
 
 } // namespace unitest

--- a/src/unitest.cc
+++ b/src/unitest.cc
@@ -113,7 +113,7 @@ int run_all_tests() {
         cout.flush();
     }
 
-    return failed.size();
+    return (int) failed.size();
 }
 
 } // namespace unitest


### PR DESCRIPTION
修改函数run_all_tests()原型，添加返回值：如果全部执行成功，返回0；否则返回失败用例的个数。返回值可以用于外部程序检查是否通过所有单元测试。