### PR TITLE
Dev

### DIFF
--- a/include/co/co/chan.h
+++ b/include/co/co/chan.h
@@ -21,7 +21,7 @@ class __coapi Pipe {
         atomic_inc(_p, mo_relaxed);
     }
 
-    void operator=(const Pipe&) = delete;
+    Pipe& operator=(const Pipe&) = delete;
 
     // read a block
     void read(void* p) const;
@@ -52,7 +52,7 @@ class Chan {
 
     Chan(const Chan& c) : _p(c._p) {}
 
-    void operator=(const Chan&) = delete;
+    Chan& operator=(const Chan&) = delete;
 
     void operator<<(const T& x) const {
         _p.write(&x);

--- a/include/co/co/event.h
+++ b/include/co/co/event.h
@@ -24,7 +24,7 @@ class __coapi Event {
         atomic_inc(_p, mo_relaxed);
     }
 
-    void operator=(const Event&) = delete;
+    Event& operator=(const Event&) = delete;
 
     /**
      * wait for a signal

--- a/include/co/co/mutex.h
+++ b/include/co/co/mutex.h
@@ -21,7 +21,7 @@ class __coapi Mutex {
         atomic_inc(_p, mo_relaxed);
     }
 
-    void operator=(const Mutex&) = delete;
+    Mutex& operator=(const Mutex&) = delete;
 
     /**
      * acquire the lock

--- a/include/co/co/pool.h
+++ b/include/co/co/pool.h
@@ -42,7 +42,7 @@ class __coapi Pool {
         atomic_inc(_p, mo_relaxed);
     }
 
-    void operator=(const Pool&) = delete;
+    Pool& operator=(const Pool&) = delete;
 
     /**
      * pop an element from the pool of the current thread 

--- a/include/co/co/wait_group.h
+++ b/include/co/co/wait_group.h
@@ -24,7 +24,7 @@ class __coapi WaitGroup {
         atomic_inc(_p, mo_relaxed);
     }
 
-    void operator=(const WaitGroup&) = delete;
+    WaitGroup& operator=(const WaitGroup&) = delete;
 
     // increase WaitGroup counter by n (1 by default)
     void add(uint32 n=1) const;

--- a/include/co/def.h
+++ b/include/co/def.h
@@ -30,7 +30,7 @@ typedef uint64_t uint64;
 
 #define DISALLOW_COPY_AND_ASSIGN(T) \
     T(const T&) = delete; \
-    void operator=(const T&) = delete
+    T& operator=(const T&) = delete
 
 #if SIZE_MAX == UINT64_MAX
 #define __arch64 1

--- a/include/co/fast.h
+++ b/include/co/fast.h
@@ -102,12 +102,12 @@ class __coapi stream {
         : _cap(cap), _size(size), _p((char*)p) {
     }
 
-    ~stream() {
+    virtual ~stream() {
         if (_p) co::free(_p, _cap);
     }
 
     stream(const stream&) = delete;
-    void operator=(const stream&) = delete;
+    stream& operator=(const stream&) = delete;
 
     stream(stream&& s) noexcept
         : _cap(s._cap), _size(s._size), _p(s._p) {

--- a/include/co/fastream.h
+++ b/include/co/fastream.h
@@ -22,7 +22,7 @@ class __coapi fastream : public fast::stream {
     ~fastream() = default;
 
     fastream(const fastream&) = delete;
-    void operator=(const fastream&) = delete;
+    fastream& operator=(const fastream&) = delete;
 
     fastream(fastream&& fs) noexcept
         : fast::stream(std::move(fs)) {

--- a/include/co/fs.h
+++ b/include/co/fs.h
@@ -127,8 +127,8 @@ class __coapi file {
     }
 
     file(const file& x) = delete;
-    void operator=(const file& x) = delete;
-    void operator=(file&& x) = delete;
+    file& operator=(const file& x) = delete;
+    file& operator=(file&& x) = delete;
 
     explicit operator bool() const;
     
@@ -298,8 +298,8 @@ class __coapi dir {
     dir(dir&& d) : _p(d._p) { d._p = 0; }
 
     dir(const dir&) = delete;
-    void operator=(const dir&) = delete;
-    void operator=(dir&&) = delete;
+    dir& operator=(const dir&) = delete;
+    dir& operator=(dir&&) = delete;
 
     // open the dir
     bool open(const char* path);

--- a/include/co/http.h
+++ b/include/co/http.h
@@ -40,7 +40,7 @@ class __coapi Client {
     ~Client();
 
     Client(const Client&) = delete;
-    void operator=(const Client&) = delete;
+    Client& operator=(const Client&) = delete;
 
     /**
      * add a HTTP header

--- a/include/co/json.h
+++ b/include/co/json.h
@@ -138,6 +138,7 @@ class __coapi Json {
     Json() noexcept : _h(0) {}
     Json(decltype(nullptr)) noexcept : _h(0) {}
     Json(Json&& v) noexcept : _h(v._h) { v._h = 0; }
+    Json(Json& v) noexcept : _h(v._h) { v._h = 0; }
     ~Json() { if (_h) this->reset(); }
 
     Json(const Json& v) = delete;
@@ -150,6 +151,11 @@ class __coapi Json {
             v._h = 0;
         }
         return *this;
+    }
+
+    // after this operation, v will be moved and becomes null
+    Json& operator=(Json& v) {
+        return this->operator=(std::move(v));
     }
 
     // make a duplicate 

--- a/include/co/json.h
+++ b/include/co/json.h
@@ -138,11 +138,10 @@ class __coapi Json {
     Json() noexcept : _h(0) {}
     Json(decltype(nullptr)) noexcept : _h(0) {}
     Json(Json&& v) noexcept : _h(v._h) { v._h = 0; }
-    Json(Json& v) noexcept : _h(v._h) { v._h = 0; }
     ~Json() { if (_h) this->reset(); }
 
     Json(const Json& v) = delete;
-    void operator=(const Json&) = delete;
+    Json& operator=(const Json&) = delete;
 
     Json& operator=(Json&& v) {
         if (&v != this) {
@@ -151,11 +150,6 @@ class __coapi Json {
             v._h = 0;
         }
         return *this;
-    }
-
-    // after this operation, v will be moved and becomes null
-    Json& operator=(Json& v) {
-        return this->operator=(std::move(v));
     }
 
     // make a duplicate 

--- a/include/co/maybe.h
+++ b/include/co/maybe.h
@@ -49,7 +49,7 @@ class maybe<T, god::enable_if_t<god::is_same<T, void>()>> final {
     }
 
     maybe(const maybe&) = delete;
-    void operator=(const maybe&) = delete;
+    maybe& operator=(const maybe&) = delete;
 
     ~maybe() = default;
 
@@ -96,7 +96,7 @@ class maybe<T, god::enable_if_t<god::is_scalar<T>()>> final {
     }
 
     maybe(const maybe&) = delete;
-    void operator=(const maybe&) = delete;
+    maybe& operator=(const maybe&) = delete;
 
     ~maybe() = default;
 
@@ -145,7 +145,7 @@ class maybe<T, god::enable_if_t<god::is_ref<T>()>> final {
     }
 
     maybe(const maybe&) = delete;
-    void operator=(const maybe&) = delete;
+    maybe& operator=(const maybe&) = delete;
 
     ~maybe() = default;
 
@@ -196,7 +196,7 @@ class maybe<T, god::enable_if_t<god::is_class<T>()>> final {
     }
 
     maybe(const maybe&) = delete;
-    void operator=(const maybe&) = delete;
+    maybe& operator=(const maybe&) = delete;
 
     ~maybe() {
         if (!this->has_error()) _t.~T();

--- a/include/co/rpc.h
+++ b/include/co/rpc.h
@@ -69,7 +69,7 @@ class __coapi Client {
     Client(const Client& c);
     ~Client();
 
-    void operator=(const Client& c) = delete;
+    Client& operator=(const Client& c) = delete;
 
     // perform a rpc request
     void call(const Json& req, Json& res);

--- a/include/co/table.h
+++ b/include/co/table.h
@@ -33,7 +33,7 @@ class table {
     }
 
     table(const table&) = delete;
-    void operator=(const table&) = delete;
+    table& operator=(const table&) = delete;
 
     T& operator[](size_t i) {
         const size_t q = i >> _xbits;      // i / _xsize

--- a/include/co/tasked.h
+++ b/include/co/tasked.h
@@ -11,7 +11,7 @@ class __coapi Tasked {
     ~Tasked();
 
     Tasked(const Tasked&) = delete;
-    void operator=(const Tasked&) = delete;
+    Tasked& operator=(const Tasked&) = delete;
 
     Tasked(Tasked&& t) {
         _p = t._p;

--- a/include/co/tcp.h
+++ b/include/co/tcp.h
@@ -182,7 +182,7 @@ class __coapi Client final {
      */
     ~Client();
 
-    void operator=(const Client& c) = delete;
+    Client& operator=(const Client& c) = delete;
 
     /**
      * recv using co::recv or ssl::recv


### PR DESCRIPTION
1、复制赋值运算符函数采用iso c++规范语法，返回类型从void ->具体的类型
2、fast.h中的stream类是可以作为基类使用的，析构函数需要设置为virtual，避免delete多态指针的时候出现内存泄漏