### PR TITLE
improve coost.pc.in code

### DIFF
--- a/cmake/coost.pc.in
+++ b/cmake/coost.pc.in
@@ -1,7 +1,5 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=${prefix}
-includedir=${prefix}/@CMAKE_INSTALL_INCLUDEDIR@
-libdir=${exec_prefix}/@CMAKE_INSTALL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
 
 Name: coost
 Description: A tiny boost library in C++11.


### PR DESCRIPTION
`CMAKE_INSTALL_LIBDIR` and `CMAKE_INSTALL_INCLUDEDIR` are not guaranteed to be absolute paths, while `CMAKE_INSTALL_FULL_LIBDIR` and `CMAKE_INSTALL_FULL_INCLUDEDIR` do, and the modified code is more concise