### PR TITLE
refine scheduler flags

### DIFF
--- a/include/co/flag.h
+++ b/include/co/flag.h
@@ -78,3 +78,7 @@ __coapi void add_flag(
 __coapi DEC_string(help);
 __coapi DEC_string(config);
 __coapi DEC_string(version);
+
+__coapi DEC_uint32(co_sched_num);
+__coapi DEC_uint32(co_stack_size);
+__coapi DEC_bool(co_debug_log);

--- a/src/co/scheduler.h
+++ b/src/co/scheduler.h
@@ -26,10 +26,6 @@
 #include <memory>
 #include <map>
 
-DEC_uint32(co_sched_num);
-DEC_uint32(co_stack_size);
-DEC_bool(co_debug_log);
-
 #define CO_DBG_LOG DLOG_IF(FLG_co_debug_log)
 
 namespace co {


### PR DESCRIPTION
有时候需要固定`FLG_co_sched_num` 比如设置1。又不想通过命令行参数。
这应该是个挺常见和重要的设置。

因为`scheduler.h`不是public，所以放到了`co.h`里了，请看是否合适（或者有更好的地方/改法？）。