### PR TITLE
feat: support co::loop_schedulers()

### DIFF
--- a/include/co/co.h
+++ b/include/co/co.h
@@ -273,6 +273,9 @@ __coapi bool on_stack(const void* p);
 // stop coroutine schedulers
 __coapi void stop_schedulers();
 
+// loop coroutine schedulers
+__coapi void loop_schedulers();
+
 } // namespace co
 
 using co::go;

--- a/src/co/scheduler.h
+++ b/src/co/scheduler.h
@@ -376,6 +376,8 @@ class SchedulerManager {
         return _scheds;
     }
 
+    void start(bool loop = false);
+
     void stop();
 
   private:


### PR DESCRIPTION
当前协程调度器是自动创建新线程启动的，这当然有好处：自动启动、使用者无需开启线程等操作。

但是有这种情况：
1. 希望把当前线程交给协程调度器，毕竟留着也没用处了，浪费资源（虽然也不大）。
2. 在主线程里，比较漂亮地实现单个线程调度模式（co_sched_num=1，做到整个进程只有一个线程（LOG除外））。

比如http server的例子：
```
flag::set_value("co_sched_num", "1");

http::Server().on_req([](const http::Req& req, http::Res& res) {}
).start(FLG_ip.c_str(), FLG_port, FLG_key.c_str(), FLG_ca.c_str());

while (true) sleep::sec(1024);
```
整个进程实际上有两个线程，不够“完美主义”。

这个feature之后，可以这么写：
```
flag::set_value("co_sched_num", "1");
flag::set_value("co_auto_sched", "false");

http::Server().on_req([](const http::Req& req, http::Res& res) {}
).start(FLG_ip.c_str(), FLG_port, FLG_key.c_str(), FLG_ca.c_str());

co::loop_schedulers();
```
做到整个进程只有一个线程！！！
