### PR TITLE
Fix compilation errors under riscv64 architecture 

### DIFF
--- a/src/co/context/arch.h
+++ b/src/co/context/arch.h
@@ -54,15 +54,13 @@
   #define ARCH_MIPS
 
 #elif defined(loongarch) || \
-      defined(_loongarch) || \
-      defined(_loongarch64) || \
+      defined(__loongarch64) || \
       defined(__loongarch__)
   #define ARCH_LOONGARCH
 
 #elif defined(riscv) || \
-      defined(_riscv) || \
-      defined(_riscv64) || \
-      defined(__riscv__)
+      defined(__riscv) || \
+      defined(__riscv_xlen)
   #define ARCH_RISCV
 
 
@@ -129,7 +127,7 @@
     defined(__ppc64__) || \
     defined(__powerpc64__) || \
     defined(__loongarch64) || \
-    defined(__riscv64) || \
+    defined(__riscv_xlen) || \
     defined(_M_X64) || \
     defined(_M_AMD64) || \
     defined(_M_IA64) || \


### PR DESCRIPTION
Using riscv64 gcc13 compile prompt error unknown arch
Refer to the definition in the latest gcc and fix it to __riscv_xlen 
The macro definition of __riscv also exists in riscv32, so __riscv_xlen is used as the CPU bit width judgment
from: https://github.com/gcc-mirror/gcc/blob/master/gcc/config/riscv/riscv.h

loongarch64: Delete useless macro judgments

### Macro definitions in loongarch64 environment in gcc and clang

```
#define __loongarch64 1
#define __loongarch__ 1
#define __loongarch_double_float 1
#define __loongarch_frlen 64
#define __loongarch_grlen 64
#define __loongarch_hard_float 1
#define __loongarch_lp64 1
```


### Macro definitions in riscv64 environment in gcc and clang

```
#define __riscv 1
#define __riscv_a 2000000
#define __riscv_arch_test 1
#define __riscv_atomic 1
#define __riscv_c 2000000
#define __riscv_cmodel_medlow 1
#define __riscv_compressed 1
#define __riscv_d 2000000
#define __riscv_div 1
#define __riscv_f 2000000
#define __riscv_fdiv 1
#define __riscv_flen 64
#define __riscv_float_abi_double 1
#define __riscv_fsqrt 1
#define __riscv_i 2000000
#define __riscv_m 2000000
#define __riscv_mul 1
#define __riscv_muldiv 1
#define __riscv_xlen 64
```
