### PR TITLE
fix: build failed if support win7

### DIFF
--- a/include/co/byte_order.h
+++ b/include/co/byte_order.h
@@ -5,6 +5,10 @@
 
 #ifdef _MSC_VER
 #pragma comment(lib, "Ws2_32.lib")
+#if _WIN32_WINNT < _WIN32_WINNT_WIN8
+  #define htonll(x) _byteswap_uint64(x)
+  #define ntohll(x) _byteswap_uint64(x)
+#endif
 #else /* mingw */
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
   #define htonll(x) __builtin_bswap64(x)


### PR DESCRIPTION
If add define -D_WIN32_WINNT=0x0601 in roder to support run on win7, it miss htnoll and nthll functions, exclude them if support win7.

Log: Fix build issue if support win7.