### PR TITLE
#365: FreeBSD Pthread get thread fix

### DIFF
--- a/src/co/co.cc
+++ b/src/co/co.cc
@@ -8,6 +8,9 @@
 #include <time.h>         // for clock_gettime
 #else
 #include <sys/time.h>     // for gettimeofday
+#ifndef __APPLE__
+#include <pthread_np.h>   // for getting proper threadid on modern BSDs but not Mac OSX
+#endif
 #endif
 #endif
 
@@ -100,7 +103,11 @@ uint32 thread_id() { return syscall(SYS_gettid); }
 #else /* for mac, bsd.. */
 uint32 thread_id() {
     uint64 x;
+#ifdef __APPLE__
     pthread_threadid_np(0, &x);
+#else
+    x = pthread_getthreadid_np();
+#endif
     return (uint32)x;
 }
 #endif


### PR DESCRIPTION
This should solve the FreeBSD pthread header issue. If you need to support older releases (such as FreeBSD 10 and under), I can add a version check for more coverage. Here's the relevant header docs: https://man.freebsd.org/cgi/man.cgi?query=pthread_getthreadid_np&sektion=3&format=html . Adding pthread_np.h without checking may break Mac builds due to how the two platforms diverged from one another.