### PR TITLE
restore library alias

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@
 file(GLOB_RECURSE SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/*.cc)
 
 add_library(co ${SRC_FILES})
+add_library(coost::co ALIAS co)
 
 target_include_directories(co
     PUBLIC


### PR DESCRIPTION
Please keep the library alias because the alias is (already) used to link your library.