### PR TITLE
fix: expected unqualified-id before numeric constant

### DIFF
--- a/include/co/time.h
+++ b/include/co/time.h
@@ -37,6 +37,8 @@ struct Mono {
 
 } // xx
 
+#undef unix
+
 extern xx::Mono mono;
 extern xx::Unix unix;
 


### PR DESCRIPTION
[https://github.com/idealvin/coost/issues/393](https://github.com/idealvin/coost/issues/393)

It is a possible solution

extern xx::Mono mono; - a global variable
extern xx::Unix unix; - a predefined macro